### PR TITLE
fix: Move attributes from task to root

### DIFF
--- a/src/reforemast/updaters.py
+++ b/src/reforemast/updaters.py
@@ -79,6 +79,7 @@ class ApplicationUpdater(Updater):
         self.obj = spinnaker_client.get(endpoint=f'/applications/{self.name}')
         attr = self.obj.pop('attributes')
         self.obj.update(attr)
+        self.obj.pop('clusters', None)
         return self.obj
 
     def push(self):

--- a/src/reforemast/updaters.py
+++ b/src/reforemast/updaters.py
@@ -77,6 +77,8 @@ class ApplicationUpdater(Updater):
     def get(self):
         """Retrieve Spinnaker Application configuration."""
         self.obj = spinnaker_client.get(endpoint=f'/applications/{self.name}')
+        attr = self.obj.pop('attributes')
+        self.obj.update(attr)
         return self.obj
 
     def push(self):


### PR DESCRIPTION
This is trying to fix an issue where app configs become read-only.